### PR TITLE
Fix startup database initialization

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,13 +1,9 @@
-const sqlite3 = require('sqlite3').verbose();
 const bcrypt = require('bcryptjs');
-const path = require('path');
-const config = require('./config');
-
-const DB_PATH = path.join(config.BASE_DIR, 'loradb', 'search_index', 'index.db');
+const indexer = require('./indexer');
 
 class Auth {
   constructor() {
-    this.db = new sqlite3.Database(DB_PATH);
+    this.db = indexer.db;
     this.ensureTable();
   }
 

--- a/server.js
+++ b/server.js
@@ -18,8 +18,10 @@ app.use('/uploads', express.static(config.UPLOAD_DIR));
 app.use(express.urlencoded({ extended: true }));
 app.use(session({ secret: config.SECRET_KEY, resave: false, saveUninitialized: false }));
 
-// simple auth middleware
-auth.createUser('admin', 'admin', 'admin');
+// initialize default admin user after DB is ready
+indexer.db.serialize(() => {
+  auth.createUser('admin', 'admin', 'admin');
+});
 
 app.use((req, res, next) => {
   if (!req.session.userId && !req.path.startsWith('/login')) {
@@ -91,4 +93,5 @@ app.post('/upload', upload.array('files'), (req, res) => {
   res.redirect('/grid');
 });
 
-app.listen(5000, () => console.log('Server running on http://localhost:5000'));
+const HOST = '0.0.0.0';
+app.listen(5000, HOST, () => console.log(`Server running on http://${HOST}:5000`));


### PR DESCRIPTION
## Summary
- share the SQLite connection between auth and indexer
- queue admin user creation so tables exist first
- bind server to `0.0.0.0` for remote access

## Testing
- `node -c server.js`
- `node -c auth.js`
- `npm start` *(then Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_686a52aa7120833396b66ad3f5b59ef7