### PR TITLE
Add script for admin user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ npm start
 The application listens on `http://localhost:5000`.
 
 > **Note**: The repository omits the `404.jpg` and `accessdenied.jpg` placeholders from `loradb/static`. Add your own copies if you want custom error images.
+
+## Initial admin account
+
+Create the first administrator account using the provided script:
+
+```bash
+node usersetup.js <username> <password>
+```

--- a/usersetup.js
+++ b/usersetup.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+/** Create an initial admin user. */
+const auth = require('./auth');
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.log('Usage: node usersetup.js <username> <password>');
+    process.exit(1);
+  }
+  const [user, password] = args;
+  auth.createUser(user, password, 'admin');
+  console.log(`Admin user '${user}' created`);
+  if (auth.db && typeof auth.db.close === 'function') {
+    auth.db.close();
+  }
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add a `usersetup.js` script to create an admin account
- document the script in the README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686a5475dd2c8333908aca36a52598ce