### PR TITLE
Add missing admin and showcase modules

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -32,6 +32,14 @@ class Auth {
   getUserById(id, cb) {
     this.db.get(`SELECT id, username, role FROM users WHERE id = ?`, [id], cb);
   }
+
+  listUsers(cb) {
+    this.db.all(`SELECT username, role FROM users ORDER BY username`, cb);
+  }
+
+  deleteUser(username, cb) {
+    this.db.run(`DELETE FROM users WHERE username = ?`, [username], cb || (() => {}));
+  }
 }
 
 module.exports = new Auth();

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const config = require('./config');
 const indexer = require('./indexer');
 const frontend = require('./frontend');
 const auth = require('./auth');
+const uploader = require('./uploader');
 
 const upload = multer({ dest: path.join(config.UPLOAD_DIR, '_tmp') });
 fs.mkdirSync(path.join(config.UPLOAD_DIR, '_tmp'), { recursive: true });
@@ -28,6 +29,14 @@ app.use((req, res, next) => {
     return res.redirect('/login');
   }
   next();
+});
+
+app.use((req, res, next) => {
+  if (!req.session.userId) return next();
+  auth.getUserById(req.session.userId, (err, user) => {
+    req.user = user || { username: 'admin', role: 'admin' };
+    next();
+  });
 });
 
 app.get('/login', (req, res) => {
@@ -56,7 +65,7 @@ app.get('/', (req, res) => {
   indexer.loraCount(loraCnt => {
     indexer.categoryCount(catCnt => {
       const stats = { lora_count: loraCnt, preview_count: indexer.previewCount(), category_count: catCnt, storage_volume: 0, top_categories: [] };
-      res.send(frontend.env.render('dashboard.html', { title: 'Dashboard', stats, recent_categories: [], recent_loras: [], user: { username: 'admin' } }));
+      res.send(frontend.env.render('dashboard.html', { title: 'Dashboard', stats, recent_categories: [], recent_loras: [], user: req.user }));
     });
   });
 });
@@ -65,7 +74,7 @@ app.get('/grid', (req, res) => {
   const q = req.query.q || '*';
   indexer.search(q, (err, rows) => {
     indexer.listCategories((err2, cats) => {
-      res.send(frontend.env.render('grid.html', { title: 'LoRA Gallery', entries: rows, query: q === '*' ? '' : q, categories: cats, selected_category: '', limit: 50, user: { username: 'admin' } }));
+      res.send(frontend.env.render('grid.html', { title: 'LoRA Gallery', entries: rows, query: q === '*' ? '' : q, categories: cats, selected_category: '', limit: 50, user: req.user }));
     });
   });
 });
@@ -75,11 +84,13 @@ app.get('/detail/:filename', (req, res) => {
   const stem = path.parse(filename).name;
   const entry = { filename, name: filename, metadata: {}, categories: [] };
   entry.previews = frontend.findPreviews(stem);
-  res.send(frontend.env.render('detail.html', { title: filename, entry, categories: [], user: { username: 'admin' } }));
+  indexer.getCategoriesFor(filename, (err, cats) => {
+    res.send(frontend.env.render('detail.html', { title: filename, entry, categories: cats || [], user: req.user }));
+  });
 });
 
 app.get('/upload', (req, res) => {
-  res.send(frontend.env.render('upload.html', { title: 'Upload', user: { username: 'admin' } }));
+  res.send(frontend.env.render('upload.html', { title: 'Upload', user: req.user }));
 });
 
 app.post('/upload', upload.array('files'), (req, res) => {
@@ -90,7 +101,103 @@ app.post('/upload', upload.array('files'), (req, res) => {
     saved.push({ filename: f.originalname });
     indexer.addMetadata({ filename: f.originalname });
   });
-  res.redirect('/grid');
+  if (req.headers.accept && !req.headers.accept.includes('text/html')) {
+    res.json(saved);
+  } else {
+    res.redirect('/grid');
+  }
+});
+
+app.get('/upload_wizard', (req, res) => {
+  res.send(frontend.env.render('upload_wizard.html', { title: 'Upload Wizard', user: req.user }));
+});
+
+app.post('/upload_previews', upload.array('files'), (req, res) => {
+  const stem = req.body.lora || '';
+  if (req.files.length === 1 && req.files[0].originalname.toLowerCase().endsWith('.zip') && !stem) {
+    uploader.savePreviewZip(req.files[0]).then(() => {
+      res.json({ status: 'ok' });
+    });
+    return;
+  }
+  uploader.savePreviewFiles(stem, req.files).then(() => {
+    if (req.headers.accept && !req.headers.accept.includes('text/html')) {
+      res.json({ status: 'ok' });
+    } else {
+      res.redirect('/detail/' + stem + '.safetensors');
+    }
+  });
+});
+
+app.get('/category_admin', (req, res) => {
+  indexer.listCategoriesWithCounts((err, cats) => {
+    res.send(frontend.env.render('category_admin.html', { title: 'Categories', categories: cats, user: req.user }));
+  });
+});
+
+app.post('/categories', (req, res) => {
+  const name = req.body.name;
+  if (!name) return res.redirect('/category_admin');
+  indexer.addCategory(name, () => res.redirect('/category_admin'));
+});
+
+app.post('/delete_category', (req, res) => {
+  indexer.deleteCategory(req.body.category_id, () => res.redirect('/category_admin'));
+});
+
+app.get('/admin/users', (req, res) => {
+  auth.listUsers((err, users) => {
+    res.send(frontend.env.render('user_admin.html', { title: 'Users', users, user: req.user }));
+  });
+});
+
+app.post('/admin/users/add', (req, res) => {
+  const { username, password, role } = req.body;
+  auth.createUser(username, password, role);
+  res.redirect('/admin/users');
+});
+
+app.post('/admin/users/delete', (req, res) => {
+  auth.deleteUser(req.body.username);
+  res.redirect('/admin/users');
+});
+
+app.get('/showcase', (req, res) => {
+  indexer.search('*', (err, rows) => {
+    const entries = rows.map(r => {
+      const stem = path.parse(r.filename).name;
+      const previews = frontend.findPreviews(stem);
+      return { filename: r.filename, name: r.name || r.filename, preview_url: previews[0] };
+    });
+    res.send(frontend.env.render('showcase.html', { title: 'Model Showcase', entries, user: req.user }));
+  });
+});
+
+app.get('/showcase_detail/:filename', (req, res) => {
+  const filename = req.params.filename;
+  const stem = path.parse(filename).name;
+  const entry = { filename, name: filename, previews: frontend.findPreviews(stem) };
+  res.send(frontend.env.render('showcase_detail.html', { title: filename, entry, user: req.user }));
+});
+
+app.get('/grid_data', (req, res) => {
+  const q = req.query.q || '*';
+  const category = req.query.category;
+  const limit = parseInt(req.query.limit || '50', 10);
+  const offset = parseInt(req.query.offset || '0', 10);
+  const cb = rows => {
+    const data = rows.map(r => {
+      const stem = path.parse(r.filename).name;
+      const preview = frontend.findPreviews(stem)[0] || null;
+      return { filename: r.filename, name: r.name, preview_url: preview };
+    });
+    res.json(data);
+  };
+  if (category) {
+    indexer.searchByCategory(parseInt(category, 10), q, cb);
+  } else {
+    indexer.search(q, (err, rows) => cb(rows.slice(offset, offset + limit)));
+  }
 });
 
 const HOST = '0.0.0.0';

--- a/uploader.js
+++ b/uploader.js
@@ -45,6 +45,40 @@ class Uploader {
     fs.unlinkSync(temp);
     return extracted;
   }
+
+  async savePreviewFiles(stem, files) {
+    const extracted = [];
+    let index = 0;
+    for (const file of files) {
+      const ext = path.extname(file.originalname).toLowerCase();
+      if (!['.png', '.jpg', '.jpeg', '.gif'].includes(ext)) continue;
+      const destName = index === 0 ? `${stem}${ext}` : `${stem}_${index}${ext}`;
+      const destPath = path.join(config.UPLOAD_DIR, destName);
+      fs.renameSync(file.path, destPath);
+      extracted.push(destPath);
+      index++;
+    }
+    return extracted;
+  }
+
+  deleteLora(filename) {
+    const filePath = path.join(config.UPLOAD_DIR, filename);
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    const stem = path.parse(filename).name;
+    const exts = ['.png', '.jpg', '.jpeg', '.gif'];
+    for (const ext of exts) {
+      for (const f of fs.readdirSync(config.UPLOAD_DIR)) {
+        if (f.startsWith(stem) && f.endsWith(ext)) {
+          fs.unlinkSync(path.join(config.UPLOAD_DIR, f));
+        }
+      }
+    }
+  }
+
+  deletePreview(filename) {
+    const filePath = path.join(config.UPLOAD_DIR, filename);
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  }
 }
 
 module.exports = new Uploader();


### PR DESCRIPTION
## Summary
- extend indexer with category helpers
- allow listing and removal of users
- support preview uploads and file deletion
- implement showcase, category admin and user admin endpoints
- provide grid data endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a5883eed08333ab4607b910f7267d