### PR TITLE
Add metadata extraction

### DIFF
--- a/metadata.js
+++ b/metadata.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+function extractMetadata(filePath, includeTensorKeys = false) {
+  const result = { filename: path.basename(filePath) };
+  try {
+    const fd = fs.openSync(filePath);
+    const headerLenBuf = Buffer.alloc(8);
+    fs.readSync(fd, headerLenBuf, 0, 8, 0);
+    const headerLen = Number(headerLenBuf.readBigUInt64LE());
+    const headerBuf = Buffer.alloc(headerLen);
+    fs.readSync(fd, headerBuf, 0, headerLen, 8);
+    fs.closeSync(fd);
+    const header = JSON.parse(headerBuf.toString('utf8'));
+    const meta = header.__metadata__ || header.metadata || {};
+    Object.assign(result, meta);
+    if (includeTensorKeys) {
+      const keys = Object.keys(header).filter(k => !k.startsWith('__'));
+      result.tensor_keys = keys.join(',');
+    }
+  } catch (err) {
+    result.error = err.message;
+  }
+  return result;
+}
+
+module.exports = { extractMetadata };

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const indexer = require('./indexer');
 const frontend = require('./frontend');
 const auth = require('./auth');
 const uploader = require('./uploader');
+const metadata = require('./metadata');
 
 const upload = multer({ dest: path.join(config.UPLOAD_DIR, '_tmp') });
 fs.mkdirSync(path.join(config.UPLOAD_DIR, '_tmp'), { recursive: true });
@@ -121,8 +122,9 @@ app.post('/upload', upload.array('files'), (req, res) => {
   req.files.forEach(f => {
     const dest = path.join(config.UPLOAD_DIR, f.originalname);
     fs.renameSync(f.path, dest);
-    saved.push({ filename: f.originalname });
-    indexer.addMetadata({ filename: f.originalname });
+    const meta = metadata.extractMetadata(dest);
+    saved.push(meta);
+    indexer.addMetadata(meta);
   });
   if (req.headers.accept && !req.headers.accept.includes('text/html')) {
     res.json(saved);


### PR DESCRIPTION
## Summary
- add `metadata.js` for reading LoRA metadata from safetensors files
- use metadata info on upload to populate the search index

## Testing
- `node -e "require('./metadata'); console.log('meta ok')"`
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686a5cac1c048333bebbf71bd1e2a721